### PR TITLE
[Git Formats] Simplify inline comment support

### DIFF
--- a/Git Formats/Git Code Owners.sublime-syntax
+++ b/Git Formats/Git Code Owners.sublime-syntax
@@ -12,11 +12,12 @@ file_extensions:
   - CODEOWNERS                # *.codeowners, ./CODEOWNERS
 
 variables:
-  comment_char: \#
+  comment_char: '[#;]'
 
 contexts:
 
   main:
+    - include: Git Common.sublime-syntax#comments
     # note:
     # - ignore whitespace at the beginning of a line
     # - patterns may not start with operators: - !
@@ -30,19 +31,17 @@ contexts:
   pattern-content:
     # note: character classes are not supported
     - meta_content_scope: meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
-    - include: comments
     - match: \s+(?=([^\@\s]+)?\@)
       set: owners
+    - include: eol-pop
     - include: Git Common.sublime-syntax#fnmatch-unquoted-file-extensions
     - include: Git Common.sublime-syntax#fnmatch-common
-    - include: eol-pop
 
   owners:
     - meta_content_scope: meta.owners.git.codeowners
-    - include: comments
+    - include: eol-pop
     - include: Git Common.sublime-syntax#username
     - include: emails
-    - include: eol-pop
 
   emails:
     - match: (?=\S)
@@ -50,21 +49,6 @@ contexts:
         - Git Common.sublime-syntax#email-meta
         - Git Common.sublime-syntax#email-name
 
-  comments:
-    - match: \s*(?={{comment_char}})
-      set: comment-start
-
-  comment-start:
-    - meta_include_prototype: false
-    - match: '{{comment_char}}'
-      scope: punctuation.definition.comment.git.codeowners
-      set: comment-body
-
-  comment-body:
-    - meta_scope: comment.line.git.codeowners
-    - match: $\n?
-      pop: 1
-
   eol-pop:
-    - match: $
+    - match: (?=\s*(?:$|{{comment_char}}))
       pop: 1

--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -125,7 +125,7 @@ contexts:
     - match: '>'
       scope: punctuation.definition.reference.email.end.git
       pop: 1
-    - match: (?=\s)
+    - match: (?=[\s{{comment_char}}])
       pop: 1
 
   username:

--- a/Git Formats/tests/syntax_test_git_codeowners
+++ b/Git Formats/tests/syntax_test_git_codeowners
@@ -1,13 +1,16 @@
 # SYNTAX TEST "Git Code Owners.sublime-syntax"
+# <- text.git.codeowners comment.line.git.codeowners punctuation.definition.comment.git.codeowners
 
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
+# <- comment.line.git.codeowners punctuation.definition.comment.git.codeowners
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.codeowners
 
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
 *       @global-owner1 @global-owner2
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
-#^^^^^^^ - meta.path - meta.owners
+#^^^^^^^ - meta
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.owners.git.codeowners
 #       ^^^^^^^^^^^^^^ meta.reference.username.git entity.name.reference.username.git
 #       ^ punctuation.definition.reference.username.git
@@ -18,13 +21,16 @@
 # precedence. When someone opens a pull request that only
 # modifies JS files, only @js-owner and not the global
 # owner(s) will be requested for a review.
-*.js    @js-owner
+*.js    @js-owner #This is an inline comment.
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^ punctuation.separator.path.fnmatch.git
-#   ^^^^ - meta.path - meta.owners
+#   ^^^^ - meta
 #       ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #       ^ punctuation.definition.reference.username.git
+#                ^ - comment - invalid - meta - entity
+#                 ^ punctuation.definition.comment.git.codeowners
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.codeowners
 
 # You can also use email addresses if you prefer. They'll be
 # used to look up users just like we do for commit author
@@ -33,7 +39,7 @@
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^ punctuation.separator.path.fnmatch.git
-#   ^ - meta.path - meta.owners
+#   ^ - meta
 #    ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 
 # In this example, @doctocat owns any files in the build/logs
@@ -44,7 +50,7 @@
 #^^^^^^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #     ^ punctuation.separator.path.fnmatch.git
 #          ^ punctuation.separator.path.fnmatch.git
-#           ^ - meta.path - meta.owners
+#           ^ - meta
 #            ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #            ^ punctuation.definition.reference.username.git
 
@@ -56,7 +62,7 @@ docs/*  docs@example.com
 #^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #   ^ punctuation.separator.path.fnmatch.git
 #    ^ constant.other.wildcard.asterisk.fnmatch.git
-#     ^^ - meta.path - meta.owners
+#     ^^ - meta
 #       ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 
 # In this example, @octocat owns any file in an apps directory
@@ -65,7 +71,7 @@ apps/ @octocat
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #   ^ punctuation.separator.path.fnmatch.git
-#    ^ - meta.path - meta.owners
+#    ^ - meta
 #     ^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #     ^ punctuation.definition.reference.username.git
 
@@ -76,20 +82,8 @@ apps/ @octocat
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
 #^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #    ^ punctuation.separator.path.fnmatch.git
-#     ^ - meta.path - meta.owners
+#     ^ - meta
 #      ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
-
--docs
-# <- invalid.illegal.operator.git.codeowners
-
-!d[oc]s
-# <- invalid.illegal.operator.git.codeowners
-# ^^^^ - keyword.control
-
-\#pattern
-# <- invalid.illegal.operator.git.codeowners
-#^ invalid.illegal.operator.git.codeowners
-# ^^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 
 # In this example, any change inside the `/scripts` directory
 # will require approval from @doctocat or @octocat.
@@ -149,3 +143,15 @@ apps/ @octocat
 #            ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #                     ^ punctuation.definition.comment.git
 #                     ^^^^^^^^ comment.line.git
+
+-docs
+# <- invalid.illegal.operator.git.codeowners
+
+!d[oc]s
+# <- invalid.illegal.operator.git.codeowners
+# ^^^^ - keyword.control
+
+\#pattern
+# <- invalid.illegal.operator.git.codeowners
+#^ invalid.illegal.operator.git.codeowners
+# ^^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners

--- a/Git Formats/tests/syntax_test_git_codeowners
+++ b/Git Formats/tests/syntax_test_git_codeowners
@@ -1,16 +1,13 @@
 # SYNTAX TEST "Git Code Owners.sublime-syntax"
-# <- text.git.codeowners comment.line.git.codeowners punctuation.definition.comment.git.codeowners
 
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
-# <- comment.line.git.codeowners punctuation.definition.comment.git.codeowners
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.codeowners
 
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence.
 *       @global-owner1 @global-owner2
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
-#^^^^^^^ - meta
+#^^^^^^^ - meta.path - meta.owners
 #       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.owners.git.codeowners
 #       ^^^^^^^^^^^^^^ meta.reference.username.git entity.name.reference.username.git
 #       ^ punctuation.definition.reference.username.git
@@ -21,16 +18,13 @@
 # precedence. When someone opens a pull request that only
 # modifies JS files, only @js-owner and not the global
 # owner(s) will be requested for a review.
-*.js    @js-owner #This is an inline comment.
+*.js    @js-owner
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^ punctuation.separator.path.fnmatch.git
-#   ^^^^ - meta
+#   ^^^^ - meta.path - meta.owners
 #       ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #       ^ punctuation.definition.reference.username.git
-#                ^ - comment - invalid - meta - entity
-#                 ^ punctuation.definition.comment.git.codeowners
-#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.git.codeowners
 
 # You can also use email addresses if you prefer. They'll be
 # used to look up users just like we do for commit author
@@ -39,7 +33,7 @@
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners constant.other.wildcard.asterisk.fnmatch.git
 #^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^ punctuation.separator.path.fnmatch.git
-#   ^ - meta
+#   ^ - meta.path - meta.owners
 #    ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 
 # In this example, @doctocat owns any files in the build/logs
@@ -50,7 +44,7 @@
 #^^^^^^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #     ^ punctuation.separator.path.fnmatch.git
 #          ^ punctuation.separator.path.fnmatch.git
-#           ^ - meta
+#           ^ - meta.path - meta.owners
 #            ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #            ^ punctuation.definition.reference.username.git
 
@@ -62,7 +56,7 @@ docs/*  docs@example.com
 #^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #   ^ punctuation.separator.path.fnmatch.git
 #    ^ constant.other.wildcard.asterisk.fnmatch.git
-#     ^^ - meta
+#     ^^ - meta.path - meta.owners
 #       ^^^^^^^^^^^^^^^^ meta.owners.git.codeowners meta.reference.email.git entity.name.reference.email.git
 
 # In this example, @octocat owns any file in an apps directory
@@ -71,7 +65,7 @@ apps/ @octocat
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #   ^ punctuation.separator.path.fnmatch.git
-#    ^ - meta
+#    ^ - meta.path - meta.owners
 #     ^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
 #     ^ punctuation.definition.reference.username.git
 
@@ -82,8 +76,20 @@ apps/ @octocat
 # <- meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
 #^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #    ^ punctuation.separator.path.fnmatch.git
-#     ^ - meta
+#     ^ - meta.path - meta.owners
 #      ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
+
+-docs
+# <- invalid.illegal.operator.git.codeowners
+
+!d[oc]s
+# <- invalid.illegal.operator.git.codeowners
+# ^^^^ - keyword.control
+
+\#pattern
+# <- invalid.illegal.operator.git.codeowners
+#^ invalid.illegal.operator.git.codeowners
+# ^^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 
 # In this example, any change inside the `/scripts` directory
 # will require approval from @doctocat or @octocat.
@@ -122,8 +128,8 @@ apps/ @octocat
 #    ^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners punctuation.separator.path.fnmatch.git
 #     ^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #           ^ - comment - invalid - meta - entity
-#            ^ punctuation.definition.comment.git.codeowners
-#            ^^^^^^^^^^^^ comment.line.git.codeowners
+#            ^ punctuation.definition.comment.git
+#            ^^^^^^^^^^^^ comment.line.git
 
 # In this example, @octocat owns any file in the `/apps`
 # directory in the root of your repository except for the `/apps/github`
@@ -141,17 +147,5 @@ apps/ @octocat
 #     ^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
 #           ^ - meta
 #            ^^^^^^^^^ meta.owners.git.codeowners meta.reference.username.git entity.name.reference.username.git
-#                     ^ punctuation.definition.comment.git.codeowners
-#                     ^^^^^^^^ comment.line.git.codeowners
-
--docs
-# <- invalid.illegal.operator.git.codeowners
-
-!d[oc]s
-# <- invalid.illegal.operator.git.codeowners
-# ^^^^ - keyword.control
-
-\#pattern
-# <- invalid.illegal.operator.git.codeowners
-#^ invalid.illegal.operator.git.codeowners
-# ^^^^^^^ meta.path.pattern.git.codeowners entity.name.pattern.git.codeowners
+#                     ^ punctuation.definition.comment.git
+#                     ^^^^^^^^ comment.line.git


### PR DESCRIPTION
It is enough to treat beginning of inline comment as end of line and pop all other contexts off stack as soon as `\s*#` is found.

As a result global comment pattern will apply to the rest of a line.

This will terminate emails at `#` and `;` in all git related syntaxes, but it does not make sense to support them in commit messages but not in CODEOWNERS.

Note: That's how Bash handles line comments for instance.